### PR TITLE
Remove Duplication

### DIFF
--- a/src/output_strategy.py
+++ b/src/output_strategy.py
@@ -60,12 +60,9 @@ class TableOutputStrategy(OutputStrategy):
         for key, values in bill_obj.items():
             table.add_row([key] + values)
 
-        table.add_row(self.generate_total_row(bill_obj))
+        table.add_row(OutputStrategy.generate_total_row(bill_obj))
 
         print(table)
-
-    def generate_total_row(self, bill_obj):
-        return OutputStrategy.generate_total_row(bill_obj)
 
 
 class CSVOutputStrategy(OutputStrategy):
@@ -100,7 +97,4 @@ class CSVOutputStrategy(OutputStrategy):
             for key, values in bill_obj.items():
                 writer.writerow([key] + values)
 
-            writer.writerow(self.generate_total_row(bill_obj))
-
-    def generate_total_row(self, bill_obj):
-        return OutputStrategy.generate_total_row(bill_obj)
+            writer.writerow(OutputStrategy.generate_total_row(bill_obj))

--- a/src/output_strategy.py
+++ b/src/output_strategy.py
@@ -27,13 +27,18 @@ class OutputStrategy(ABC):
         Generate a total row for the output.
 
         Returns:
-            list: The first element is the label string ("Total"), and each subsequent element is the sum of the corresponding column in the bill_obj values, rounded to 2 decimal places. The order of columns matches the order in the bill_obj value lists.
+            list: The first element is the label string ("Total"), and each subsequent element is the sum of the corresponding column in the bill_obj values, rounded to 2 decimal places.
+            The order of columns matches the order in the bill_obj value lists.
         """
         if not bill_obj:
             return ["Total"]
         columns = list(zip(*bill_obj.values()))
         totals = [round(sum(col), 2) for col in columns]
-        return ["Total"] + totals
+        # Split the long line for readability and to avoid line-too-long warning
+        return [
+            "Total",
+            *totals
+        ]
 
 
 class TableOutputStrategy(OutputStrategy):

--- a/src/output_strategy.py
+++ b/src/output_strategy.py
@@ -27,18 +27,18 @@ class OutputStrategy(ABC):
         Generate a total row for the output.
 
         Returns:
-            list: The first element is the label string ("Total"), and each subsequent element is the sum of the corresponding column in the bill_obj values, rounded to 2 decimal places.
-            The order of columns matches the order in the bill_obj value lists.
+            list: The first element is the label string ("Total"), and each subsequent element is the sum of the
+            corresponding column in the bill_obj values, rounded to 2 decimal places. The order of columns matches
+            the order in the bill_obj value lists.
         """
         if not bill_obj:
             return ["Total"]
         columns = list(zip(*bill_obj.values()))
-        totals = [round(sum(col), 2) for col in columns]
-        # Split the long line for readability and to avoid line-too-long warning
-        return [
-            "Total",
-            *totals
+        totals = [
+            round(sum(col), 2)
+            for col in columns
         ]
+        return ["Total"] + totals
 
 
 class TableOutputStrategy(OutputStrategy):

--- a/src/output_strategy.py
+++ b/src/output_strategy.py
@@ -21,6 +21,21 @@ class OutputStrategy(ABC):
         Abstract method to output a bill object.
         """
 
+    @staticmethod
+    def generate_total_row(bill_obj):
+        """
+        Generate a total row for the output.
+        """
+        return [
+            "Total",
+            round(sum(value[0] for value in bill_obj.values()), 2),
+            round(sum(value[1] for value in bill_obj.values()), 2),
+            round(sum(value[2] for value in bill_obj.values()), 2),
+            round(sum(value[3] for value in bill_obj.values()), 2),
+            round(sum(value[4] for value in bill_obj.values()), 2),
+            round(sum(value[5] for value in bill_obj.values()), 2),
+        ]
+
 
 class TableOutputStrategy(OutputStrategy):
     """
@@ -50,18 +65,7 @@ class TableOutputStrategy(OutputStrategy):
         print(table)
 
     def generate_total_row(self, bill_obj):
-        """
-        Generate a total row for the table.
-        """
-        return [
-            "Total",
-            round(sum(value[0] for value in bill_obj.values()), 2),
-            round(sum(value[1] for value in bill_obj.values()), 2),
-            round(sum(value[2] for value in bill_obj.values()), 2),
-            round(sum(value[3] for value in bill_obj.values()), 2),
-            round(sum(value[4] for value in bill_obj.values()), 2),
-            round(sum(value[5] for value in bill_obj.values()), 2),
-        ]
+        return OutputStrategy.generate_total_row(bill_obj)
 
 
 class CSVOutputStrategy(OutputStrategy):
@@ -99,15 +103,4 @@ class CSVOutputStrategy(OutputStrategy):
             writer.writerow(self.generate_total_row(bill_obj))
 
     def generate_total_row(self, bill_obj):
-        """
-        Generate a total row for the CSV file.
-        """
-        return [
-            "Total",
-            round(sum(value[0] for value in bill_obj.values()), 2),
-            round(sum(value[1] for value in bill_obj.values()), 2),
-            round(sum(value[2] for value in bill_obj.values()), 2),
-            round(sum(value[3] for value in bill_obj.values()), 2),
-            round(sum(value[4] for value in bill_obj.values()), 2),
-            round(sum(value[5] for value in bill_obj.values()), 2),
-        ]
+        return OutputStrategy.generate_total_row(bill_obj)

--- a/src/output_strategy.py
+++ b/src/output_strategy.py
@@ -25,16 +25,15 @@ class OutputStrategy(ABC):
     def generate_total_row(bill_obj):
         """
         Generate a total row for the output.
+
+        Returns:
+            list: The first element is the label string ("Total"), and each subsequent element is the sum of the corresponding column in the bill_obj values, rounded to 2 decimal places. The order of columns matches the order in the bill_obj value lists.
         """
-        return [
-            "Total",
-            round(sum(value[0] for value in bill_obj.values()), 2),
-            round(sum(value[1] for value in bill_obj.values()), 2),
-            round(sum(value[2] for value in bill_obj.values()), 2),
-            round(sum(value[3] for value in bill_obj.values()), 2),
-            round(sum(value[4] for value in bill_obj.values()), 2),
-            round(sum(value[5] for value in bill_obj.values()), 2),
-        ]
+        if not bill_obj:
+            return ["Total"]
+        columns = list(zip(*bill_obj.values()))
+        totals = [round(sum(col), 2) for col in columns]
+        return ["Total"] + totals
 
 
 class TableOutputStrategy(OutputStrategy):


### PR DESCRIPTION
This pull request refactors the `generate_total_row` method in the `OutputStrategy` class to improve code reuse and maintainability. The method is now defined as a static method in the base class and reused across both `TableOutputStrategy` and `CSVOutputStrategy`.

### Refactoring for code reuse:
* [`src/output_strategy.py`](diffhunk://#diff-09b1fef95cd5b75bd1e9f3a0014ee4d5e9926845a64ed7c471674dba46551b4fR24-R42): The `generate_total_row` method was moved from being an instance method in each subclass to a static method in the `OutputStrategy` base class. This eliminates duplicate implementations and ensures consistent behavior for generating the total row.

### Updates to subclasses:
* [`src/output_strategy.py`](diffhunk://#diff-09b1fef95cd5b75bd1e9f3a0014ee4d5e9926845a64ed7c471674dba46551b4fL48-L65): Updated `TableOutputStrategy` to call the static `OutputStrategy.generate_total_row` method instead of its own implementation.
* [`src/output_strategy.py`](diffhunk://#diff-09b1fef95cd5b75bd1e9f3a0014ee4d5e9926845a64ed7c471674dba46551b4fL99-R104): Updated `CSVOutputStrategy` to call the static `OutputStrategy.generate_total_row` method instead of its own implementation.