### PR TITLE
Add June 2025 billing data

### DIFF
--- a/src/bills.yaml
+++ b/src/bills.yaml
@@ -1,3 +1,12 @@
+- month: 'June 2025'
+  readings:
+    Papa: 43668
+    Jack: 52238
+    Ian: 44233
+    Ajin: 14808
+  electric: 5255
+  water: 664.82
+  internet: 2100
 - month: 'May 2025'
   readings:
     Papa: 43446


### PR DESCRIPTION
This pull request updates the `src/bills.yaml` file to include utility bill details for June 2025, including readings for electricity, water, and internet.

Key changes:

* Added June 2025 utility bill details, including:
  - Electricity readings for `Papa`, `Jack`, `Ian`, and `Ajin`.
  - Costs for electricity (`5255`), water (`664.82`), and internet (`2100`).