### PR TITLE
Add August 2025 billing data

### DIFF
--- a/src/bills.yaml
+++ b/src/bills.yaml
@@ -1,3 +1,12 @@
+- month: 'August 2025'
+  readings:
+    Papa: 44125
+    Jack: 56115
+    Ian: 47582
+    Ajin: 15475
+  electric: 4657.09
+  water: 367.67
+  internet: 2100
 - month: 'July 2025'
   readings:
     Papa: 43873


### PR DESCRIPTION
This pull request adds billing data for August 2025 to the `src/bills.yaml` file, including updated readings and amounts for electric, water, and internet.

* Added new entry for August 2025 with updated readings for Papa, Jack, Ian, and Ajin, as well as electric, water, and internet bill amounts.